### PR TITLE
Swap use of memcpy() for memmove()

### DIFF
--- a/engine/EngineConsoleCommand.c
+++ b/engine/EngineConsoleCommand.c
@@ -153,7 +153,7 @@ void Cbuf_Execute (void)
 		{
 			i++;
 			cmd_text.cursize -= i;
-			memcpy(text, text + i, cmd_text.cursize);
+			memmove(text, text + i, cmd_text.cursize);
 		}
 
 		// Execute the command line


### PR DESCRIPTION
Valgrind warns of source/destination regions overlapping here.